### PR TITLE
use actual binary name in clap_complete

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,12 +13,7 @@ fn main() -> Result<()> {
 
     if let Some(shell) = cli.completions {
         let bin_name = env::args().next().expect("impossible");
-        clap_complete::generate(
-            shell,
-            &mut Cli::command(),
-            bin_name,
-            &mut std::io::stdout(),
-        );
+        clap_complete::generate(shell, &mut Cli::command(), bin_name, &mut std::io::stdout());
         std::process::exit(0);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,15 +6,17 @@ use dioxionary::{
     cli::{Action, Cli, Parser},
     history, list_dicts, query, repl,
 };
+use std::env;
 
 fn main() -> Result<()> {
     let cli: Cli = Cli::parse();
 
     if let Some(shell) = cli.completions {
+        let bin_name = env::args().next().expect("impossible");
         clap_complete::generate(
             shell,
             &mut Cli::command(),
-            "dioxionary",
+            bin_name,
             &mut std::io::stdout(),
         );
         std::process::exit(0);


### PR DESCRIPTION
Replace hardcoded names with binary executable names, fix the problem that the shell auto-completion is still the original command after linking aliases.

before fix:

```
$ ln -sf /usr/local/bin/dioxionary /usr/local/bin/dx
$ dx -c fish
complete -c dioxionary -n "__fish_use_subcommand" -s l -l local -d 'Specify local dictionary' -r
...
```

after:

```
$ ln -sf /usr/local/bin/dioxionary /usr/local/bin/dx
$ dx -c fish
complete -c dx -n "__fish_use_subcommand" -s l -l local -d 'Specify local dictionary' -r
...
```
